### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Java CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/maroontress/Clione.Java/security/code-scanning/1](https://github.com/maroontress/Clione.Java/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions of the GITHUB_TOKEN. The best way to do this is to add the block at the root level of the workflow file, so it applies to all jobs unless overridden. For a typical CI workflow that only checks out code and runs builds/tests, the minimal required permission is `contents: read`. This change should be made at the top of the `.github/workflows/gradle.yml` file, immediately after the `name` field and before the `on` field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
