### PR TITLE
Fix the token type of '#' and '##'

### DIFF
--- a/src/main/java/com/maroontress/clione/LexicalParser.java
+++ b/src/main/java/com/maroontress/clione/LexicalParser.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
+
 import com.maroontress.clione.impl.DefaultLexicalParser;
 
 /**
@@ -76,6 +78,14 @@ public interface LexicalParser extends AutoCloseable {
         @throws IOException If an I/O error occurs.
     */
     Optional<Token> next() throws IOException;
+
+    /**
+        Returns the unmodifiable {@link Set} containing the reserved words
+        that this parser uses.
+
+        @return The unmodifiable {@link Set} containing the reserved words.
+    */
+    Set<String> getReservedWords();
 
     /**
         Returns a new {@link LexicalParser} object.

--- a/src/main/java/com/maroontress/clione/impl/Digraphs.java
+++ b/src/main/java/com/maroontress/clione/impl/Digraphs.java
@@ -43,11 +43,11 @@ public final class Digraphs {
         stores in its builder.
 
         @param x The transcriber.
-        @return The token type ({@link TokenType#DIRECTIVE}).
+        @return The token type ({@link TokenType#PUNCTUATOR}).
     */
     public static TokenType toDirective(Transcriber x) {
         x.getBuilder().replaceDigraph('#');
-        return TokenType.DIRECTIVE;
+        return TokenType.PUNCTUATOR;
     }
 
     /**
@@ -56,11 +56,11 @@ public final class Digraphs {
         stores in its builder.
 
         @param x The transcriber.
-        @return The token type ({@link TokenType#UNKNOWN}).
+        @return The token type ({@link TokenType#PUNCTUATOR}).
     */
     public static TokenType toUnknownDoubleNumberSign(Transcriber x) {
         x.getBuilder().replaceDigraph('#', '#');
-        return TokenType.UNKNOWN;
+        return TokenType.PUNCTUATOR;
     }
 
     /**

--- a/src/main/java/com/maroontress/clione/impl/Switches.java
+++ b/src/main/java/com/maroontress/clione/impl/Switches.java
@@ -196,9 +196,9 @@ public final class Switches {
 
     private static final class Sharp {
         static final Case CASE = Case.of(
-                '#', TokenType.DIRECTIVE,
+                '#', TokenType.PUNCTUATOR,
                 // #
-                Case.of('#', x -> TokenType.UNKNOWN));
+                Case.of('#', x -> TokenType.PUNCTUATOR));
     }
 
     private static final class Percent {

--- a/src/test/java/com/maroontress/clione/LexicalParserTest.java
+++ b/src/test/java/com/maroontress/clione/LexicalParserTest.java
@@ -312,6 +312,65 @@ public final class LexicalParserTest {
     }
 
     @Test
+    public void sharpAsPunctuator() {
+        var s = """
+            #define IGNORE(x, y)
+            IGNORE(#, ##)
+            """;
+        var childList = List.of(
+                pair("define", TokenType.DIRECTIVE_NAME),
+                pair(" ", TokenType.DELIMITER),
+                pair("IGNORE", TokenType.IDENTIFIER),
+                pair("(", TokenType.PUNCTUATOR),
+                pair("x", TokenType.IDENTIFIER),
+                pair(",", TokenType.PUNCTUATOR),
+                pair(" ", TokenType.DELIMITER),
+                pair("y", TokenType.IDENTIFIER),
+                pair(")", TokenType.PUNCTUATOR),
+                pair("\n", TokenType.DIRECTIVE_END));
+        var list = List.of(
+                pair("#", TokenType.DIRECTIVE, childList),
+                pair("IGNORE", TokenType.IDENTIFIER),
+                pair("(", TokenType.PUNCTUATOR),
+                pair("#", TokenType.PUNCTUATOR),
+                pair(",", TokenType.PUNCTUATOR),
+                pair(" ", TokenType.DELIMITER),
+                pair("##", TokenType.PUNCTUATOR),
+                pair(")", TokenType.PUNCTUATOR),
+                pair("\n", TokenType.DELIMITER));
+        test(s, list);
+    }
+
+    @Test
+    public void sharpAsDirective() {
+        var s = """
+            #define IGNORE(x)
+            IGNORE(
+            #
+            )
+            """;
+        var defineIgnore = List.of(
+                pair("define", TokenType.DIRECTIVE_NAME),
+                pair(" ", TokenType.DELIMITER),
+                pair("IGNORE", TokenType.IDENTIFIER),
+                pair("(", TokenType.PUNCTUATOR),
+                pair("x", TokenType.IDENTIFIER),
+                pair(")", TokenType.PUNCTUATOR),
+                pair("\n", TokenType.DIRECTIVE_END));
+        var emptyChildList = List.of(
+                pair("\n", TokenType.DIRECTIVE_END));
+        var list = List.of(
+                pair("#", TokenType.DIRECTIVE, defineIgnore),
+                pair("IGNORE", TokenType.IDENTIFIER),
+                pair("(", TokenType.PUNCTUATOR),
+                pair("\n", TokenType.DELIMITER),
+                pair("#", TokenType.DIRECTIVE, emptyChildList),
+                pair(")", TokenType.PUNCTUATOR),
+                pair("\n", TokenType.DELIMITER));
+        test(s, list);
+    }
+
+    @Test
     public void includeDirective0() {
         var s = """
             #include/* COMMENT


### PR DESCRIPTION
- Add the getReservedWords() method to the LexicalParser interface.
- Change the type of the '#' and '##' tokens to PUNCTUATOR when they are not the first token on the line.
- Add test cases.