### PR TITLE
Filename propagation in LexicalParser and SourceChar

### DIFF
--- a/src/main/java/com/maroontress/clione/LexicalParser.java
+++ b/src/main/java/com/maroontress/clione/LexicalParser.java
@@ -80,6 +80,13 @@ public interface LexicalParser extends AutoCloseable {
     Optional<Token> next() throws IOException;
 
     /**
+        Returns the filename.
+
+        @return The filename. Or {@code null} if no filename is specified.
+    */
+    String getFilename();
+
+    /**
         Returns the unmodifiable {@link Set} containing the reserved words
         that this parser uses.
 
@@ -97,7 +104,21 @@ public interface LexicalParser extends AutoCloseable {
         @return The new {@link LexicalParser} object.
     */
     static LexicalParser of(Reader reader) {
-        return new DefaultLexicalParser(reader);
+        return new DefaultLexicalParser(reader, null, Keywords.C11);
+    }
+
+    /**
+        Returns a new {@link LexicalParser} object.
+
+        <p>The instance considers {@link Keywords#C11} as reserved
+        keywords.</p>
+
+        @param reader The reader that provides the stream of the source file.
+        @param filename The filename.
+        @return The new {@link LexicalParser} object.
+    */
+    static LexicalParser of(Reader reader, String filename) {
+        return new DefaultLexicalParser(reader, filename, Keywords.C11);
     }
 
     /**
@@ -111,6 +132,23 @@ public interface LexicalParser extends AutoCloseable {
         @return The new {@link LexicalParser} object.
     */
     static LexicalParser of(Reader reader, Collection<String> reservedWords) {
-        return new DefaultLexicalParser(reader, reservedWords);
+        return new DefaultLexicalParser(reader, null, reservedWords);
+    }
+
+    /**
+        Returns a new {@link LexicalParser} object with the specified reserved
+        words.
+
+        @param reader The reader that provides the stream of the source file.
+        @param filename The filename.
+        @param reservedWords The collection that contains reserved words.
+            Note that the constructor copies the collection, so changes to the
+            collection do not affect this instance.
+        @return The new {@link LexicalParser} object.
+    */
+    static LexicalParser of(Reader reader,
+            String filename,
+            Collection<String> reservedWords) {
+        return new DefaultLexicalParser(reader, filename, reservedWords);
     }
 }

--- a/src/main/java/com/maroontress/clione/SourceChar.java
+++ b/src/main/java/com/maroontress/clione/SourceChar.java
@@ -28,6 +28,7 @@ public interface SourceChar {
         <p>This object behaves as follows:</p>
         <ul>
         <li>The {@link #isEof()} method returns {@code true}</li>
+        <li>The {@link #getFilename()} method returns {@code null}</li>
         <li>The {@link #toChar()} and {@link #getSpan()} methods throw an
         {@link IllegalStateException}</li>
         <li>The {@link #getChildren()} method returns {@link #EMPTY_LIST}</li>
@@ -38,8 +39,12 @@ public interface SourceChar {
         instead.</p>
 
         <p>Note that this is an immutable object.</p>
+
+        @deprecated Not for public use in the future. This field is expected to
+        be removed.
     */
-    SourceChar STATIC_EOF = new Eof() {
+    @Deprecated
+    SourceChar STATIC_EOF = new Eof(null) {
         @Override
         public SourceSpan getSpan() {
             throw new IllegalStateException();
@@ -50,6 +55,13 @@ public interface SourceChar {
             return EMPTY_LIST;
         }
     };
+
+    /**
+        Returns the filename.
+
+        @return The filename. Or {@code null} if no filename is specified.
+    */
+    String getFilename();
 
     /**
         Returns whether this object represents EOF.

--- a/src/main/java/com/maroontress/clione/Tokens.java
+++ b/src/main/java/com/maroontress/clione/Tokens.java
@@ -135,7 +135,7 @@ public final class Tokens {
     }
 
     private static Optional<TokenType> getTokenType(String tokenString) {
-        var source = new ReaderSource(new StringReader(tokenString));
+        var source = new ReaderSource(new StringReader(tokenString), null);
         var x = new Transcriber(source);
         try {
             var type = x.readToken();

--- a/src/main/java/com/maroontress/clione/impl/DefaultLexicalParser.java
+++ b/src/main/java/com/maroontress/clione/impl/DefaultLexicalParser.java
@@ -26,31 +26,21 @@ public final class DefaultLexicalParser implements LexicalParser {
     /**
         Creates a new instance.
 
-        <p>The instance considers {@link Keywords#C11} as reserved
-        words.</p>
-
         @param reader The reader that provides the stream of the source file.
-    */
-    public DefaultLexicalParser(Reader reader) {
-        this(reader, Keywords.C11);
-    }
-
-    /**
-        Creates a new instance.
-
-        @param reader The reader that provides the stream of the source file.
+        @param filename The filename.
         @param reservedWords The collection that contains reserved keywords.
-        Note that the constructor copies the collection, so changes to the
-        collection do not affect this instance.
+            Note that the constructor copies the collection, so changes to the
+            collection do not affect this instance.
     */
-    public DefaultLexicalParser(Reader reader,
-                                Collection<String> reservedWords) {
-        this(reader, Set.copyOf(reservedWords));
+    public DefaultLexicalParser(Reader reader, String filename,
+            Collection<String> reservedWords) {
+        this(reader, filename, Set.copyOf(reservedWords));
     }
 
-    private DefaultLexicalParser(Reader reader, Set<String> reservedWords) {
+    private DefaultLexicalParser(Reader reader, String filename,
+            Set<String> reservedWords) {
         source = new PhaseTwoSource(new PhaseOneSource(
-                new ReaderSource(reader)));
+                new ReaderSource(reader, filename)));
         this.reservedWords = reservedWords;
     }
 
@@ -75,6 +65,12 @@ public final class DefaultLexicalParser implements LexicalParser {
     @Override
     public SourceLocation getLocation() {
         return source.getLocation();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getFilename() {
+        return source.getFilename();
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/maroontress/clione/impl/Eof.java
+++ b/src/main/java/com/maroontress/clione/impl/Eof.java
@@ -9,8 +9,21 @@ import com.maroontress.clione.SourceSpan;
 */
 public abstract class Eof implements SourceChar {
 
-    /**　Creates a new instance.　*/
-    protected Eof() {
+    private final String filename;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param filename The filename.
+     */
+    protected Eof(String filename) {
+        this.filename = filename;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public final String getFilename() {
+        return filename;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/maroontress/clione/impl/PhaseOneSource.java
+++ b/src/main/java/com/maroontress/clione/impl/PhaseOneSource.java
@@ -33,6 +33,12 @@ public final class PhaseOneSource implements Source {
 
     /** {@inheritDoc} */
     @Override
+    public String getFilename() {
+        return source.getFilename();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public SourceLocation getLocation() {
         return source.getLocation();
     }

--- a/src/main/java/com/maroontress/clione/impl/PhaseTwoSource.java
+++ b/src/main/java/com/maroontress/clione/impl/PhaseTwoSource.java
@@ -34,6 +34,12 @@ public final class PhaseTwoSource implements Source {
 
     /** {@inheritDoc} */
     @Override
+    public String getFilename() {
+        return source.getFilename();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public SourceLocation getLocation() {
         return source.getLocation();
     }
@@ -81,7 +87,7 @@ public final class PhaseTwoSource implements Source {
             return c;
         }
         if (c.isEof()) {
-            return SourceChars.eof(list);
+            return SourceChars.eof(getFilename(), list);
         }
         return SourceChars.of(list, c);
     }

--- a/src/main/java/com/maroontress/clione/impl/ReaderSource.java
+++ b/src/main/java/com/maroontress/clione/impl/ReaderSource.java
@@ -14,6 +14,7 @@ import com.maroontress.clione.SourceLocation;
 public final class ReaderSource implements Source {
 
     private final UnifiedNewlineReader reader;
+    private final String filename;
     private final Deque<SourceChar> stack;
     private int line = 1;
     private int column = 1;
@@ -22,9 +23,11 @@ public final class ReaderSource implements Source {
         Creates a new source.
 
         @param reader The reader from which characters will be read.
+        @param filename The filename.
     */
-    public ReaderSource(Reader reader) {
+    public ReaderSource(Reader reader, String filename) {
         this.reader = new UnifiedNewlineReader(reader);
+        this.filename = filename;
         stack = new ArrayDeque<>();
     }
 
@@ -32,6 +35,12 @@ public final class ReaderSource implements Source {
     @Override
     public void close() throws IOException {
         reader.close();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getFilename() {
+        return filename;
     }
 
     /** {@inheritDoc} */
@@ -51,9 +60,9 @@ public final class ReaderSource implements Source {
         }
         var i = reader.read();
         if (i == -1) {
-            return SourceChars.eof();
+            return SourceChars.eof(filename);
         }
-        var c = SourceChars.of((char) i, column, line);
+        var c = SourceChars.of((char) i, filename, column, line);
         if (i == '\n') {
             column = 1;
             ++line;
@@ -83,6 +92,6 @@ public final class ReaderSource implements Source {
         }
         var nextColumn = (Character.isLowSurrogate((char) next))
                 ? column : column + 1;
-        stack.addFirst(SourceChars.of((char) next, nextColumn, line));
+        stack.addFirst(SourceChars.of((char) next, filename, nextColumn, line));
     }
 }

--- a/src/main/java/com/maroontress/clione/impl/Source.java
+++ b/src/main/java/com/maroontress/clione/impl/Source.java
@@ -18,6 +18,13 @@ public interface Source {
     void close() throws IOException;
 
     /**
+        Returns the filename.
+
+        @return The filename. Or {@code null} if no filename is specified.
+    */
+    String getFilename();
+
+    /**
         Returns the current location of this source.
 
         @return The current location.
@@ -36,11 +43,6 @@ public interface Source {
         {@link Source} or {@link Reader}. It may also replace one or more
         {@link SourceChar} objects with another {@link SourceChar} object and
         return it.</p>
-
-        <p>The return value representing EOF may differ from
-        {@link SourceChar#STATIC_EOF}. Do not compare it with
-        {@link SourceChar#STATIC_EOF}, use {@link SourceChar#isEof()} method
-        instead.</p>
 
         @return The new {@link SourceChar} object.
         @throws IOException If an I/O error occurs.


### PR DESCRIPTION
- Add SourceChar#getFilename().
- Add LexicalParser#getFilename().
- Add new factory methods of(Reader, String) and of(Reader, String, Collection) to LexicalParser interface.
- Deprecate SourceChar.STATIC_EOF.
- Change a new Eof instance to be created for each source, carrying the appropriate filename.